### PR TITLE
Allow ssh deploy key

### DIFF
--- a/pkg/defaults/substitutions.go
+++ b/pkg/defaults/substitutions.go
@@ -3,4 +3,7 @@ package defaults
 const (
 	SubstitutionRadixBuildSecretsSource string = "$(radix.build-secrets)"
 	SubstitutionRadixBuildSecretsTarget string = "build-secrets"
+
+	SubstitutionRadixGitDeployKeySource string = "$(radix.git-deploy-key)"
+	SubstitutionRadixGitDeployKeyTarget string = "radix-git-deploy-key"
 )

--- a/pkg/pipeline/prepare_pipelines.go
+++ b/pkg/pipeline/prepare_pipelines.go
@@ -13,6 +13,7 @@ import (
 	commonErrors "github.com/equinor/radix-common/utils/errors"
 	"github.com/equinor/radix-common/utils/maps"
 	"github.com/equinor/radix-operator/pipeline-runner/model"
+	operatorDefaults "github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-operator/pkg/apis/kube"
 	v1 "github.com/equinor/radix-operator/pkg/apis/radix/v1"
 	"github.com/equinor/radix-tekton/pkg/defaults"
@@ -27,6 +28,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var privateSshFolderMode int32 = 600
 
 func (ctx *pipelineContext) preparePipelinesJob() (*model.PrepareBuildContext, error) {
 	buildContext := model.PrepareBuildContext{}
@@ -414,6 +417,8 @@ func getTasks(pipelineFilePath string) (map[string]pipelinev1.Task, error) {
 			return nil, fmt.Errorf("failed to read the file %s: %v", fileName, err)
 		}
 		fileData = []byte(strings.ReplaceAll(string(fileData), defaults.SubstitutionRadixBuildSecretsSource, defaults.SubstitutionRadixBuildSecretsTarget))
+		fileData = []byte(strings.ReplaceAll(string(fileData), defaults.SubstitutionRadixGitDeployKeySource, defaults.SubstitutionRadixGitDeployKeyTarget))
+
 		err = yaml.Unmarshal(fileData, &fileMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read data from the file %s: %v", fileName, err)
@@ -427,9 +432,23 @@ func getTasks(pipelineFilePath string) (map[string]pipelinev1.Task, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to load the task from the file %s: %v", fileData, err)
 		}
+
+		addGitDeployKeyVolume(&task)
 		taskMap[task.Name] = task
 	}
 	return taskMap, nil
+}
+
+func addGitDeployKeyVolume(task *pipelinev1.Task) {
+	task.Spec.Volumes = append(task.Spec.Volumes, corev1.Volume{
+		Name: defaults.SubstitutionRadixGitDeployKeyTarget,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName:  operatorDefaults.GitPrivateKeySecretName,
+				DefaultMode: &privateSshFolderMode,
+			},
+		},
+	})
 }
 
 func fileMapContainsTektonTask(fileMap map[interface{}]interface{}) bool {

--- a/pkg/pipeline/prepare_pipelines.go
+++ b/pkg/pipeline/prepare_pipelines.go
@@ -29,7 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var privateSshFolderMode int32 = 600
+var privateSshFolderMode int32 = 0444
 
 func (ctx *pipelineContext) preparePipelinesJob() (*model.PrepareBuildContext, error) {
 	buildContext := model.PrepareBuildContext{}

--- a/pkg/pipeline/validation/task_validations.go
+++ b/pkg/pipeline/validation/task_validations.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	operatorDefaults "github.com/equinor/radix-operator/pkg/apis/defaults"
 	"github.com/equinor/radix-tekton/pkg/defaults"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -99,5 +100,5 @@ func isRadixBuildSecret(secretName string) bool {
 	return strings.EqualFold(secretName, defaults.SubstitutionRadixBuildSecretsTarget)
 }
 func isRadixGitDeployKeySecret(secretName string) bool {
-	return strings.EqualFold(secretName, defaults.SubstitutionRadixGitDeployKeyTarget)
+	return strings.EqualFold(secretName, operatorDefaults.GitPrivateKeySecretName)
 }

--- a/pkg/pipeline/validation/task_validations.go
+++ b/pkg/pipeline/validation/task_validations.go
@@ -44,6 +44,11 @@ func validateTaskSecretRefDoesNotExist(task *pipelinev1.Task) []error {
 			if isRadixBuildSecret(volume.Secret.SecretName) {
 				continue
 			}
+
+			if isRadixGitDeployKeySecret(volume.Secret.SecretName) {
+				continue
+			}
+
 			return errorTaskContainsSecretRef(task)
 		}
 	}
@@ -92,4 +97,7 @@ func containerEnvVarHasNonRadixSecretRef(envVars []corev1.EnvVar) bool {
 
 func isRadixBuildSecret(secretName string) bool {
 	return strings.EqualFold(secretName, defaults.SubstitutionRadixBuildSecretsTarget)
+}
+func isRadixGitDeployKeySecret(secretName string) bool {
+	return strings.EqualFold(secretName, defaults.SubstitutionRadixGitDeployKeyTarget)
 }


### PR DESCRIPTION
Test tekton task:

`rihagtest.azurecr.io/alpine-slim:1` requires private pull image secrets, but only includes git and ssh, and sets up a `git` user with uid 1000.

`id_rsa` and `known_hosts` files are owned by root but mounted with access rights 444 (everyone can read) when used in a step

```yaml
apiVersion: tekton.dev/v1
kind: Task
metadata:
  name: git
spec:
  stepTemplate:
    image: rihagtest.azurecr.io/alpine-slim:1
    volumeMounts:
      - name: $(radix.git-deploy-key)
        mountPath: /home/git/.ssh
      - name: source-volume
        mountPath: /var/source
    securityContext:
      runAsUser: 1000

  steps:

    - name: clone-github
      command:
        - git
        - clone
        - git@github.com:Equinor-Playground/rihag-edc23-radix-1.git
        - /var/source/branch

    - name: show-repo
      script: |
        #!/usr/bin/env sh
        ls -la /var/source/branch

  volumes:
    - name: source-volume
      emptyDir: { }

```